### PR TITLE
Update artifact.classifier to java9ea

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <sureFireOptions9 />
       <sureFireForks9>false</sureFireForks9>
-      <artifact.classifier />
+      <artifact.classifier>-java9ea</artifact.classifier>
 
       <felix.bundle.plugin.version>3.3.0</felix.bundle.plugin.version>
       <felix.version>5.6.2</felix.version>


### PR DESCRIPTION
Update artifact.classifier to java9ea to avoid gradle error `inconsistent module metadata found`.  This was reported in brettwooldridge/HikariCP#958.  See https://github.com/brettwooldridge/HikariCP/issues/958